### PR TITLE
Conflicted dependencies with Rails 4

### DIFF
--- a/sequenced.gemspec
+++ b/sequenced.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "activesupport", "~> 3.0"
-  s.add_dependency "activerecord", "~> 3.0"
-  s.add_development_dependency "rails", "~> 3.1"
+  s.add_dependency "activesupport", ">= 3.0"
+  s.add_dependency "activerecord", ">= 3.0"
+  s.add_development_dependency "rails", ">= 3.1"
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Bundler message:

```
Bundler could not find compatible versions for gem "activerecord":
  In Gemfile:
    sequenced (>= 1.3.0) ruby depends on
      activerecord (~> 3.0) ruby

    rails (= 4.0.0.rc2) ruby depends on
      activerecord (4.0.0.rc2)
```
