### PR TITLE
Run `skip` lambda before accessing column

### DIFF
--- a/lib/sequenced/generator.rb
+++ b/lib/sequenced/generator.rb
@@ -11,7 +11,7 @@ module Sequenced
     end
 
     def set
-      return if id_set? || skip?
+      return if skip? || id_set?
       lock_table
       record.send(:"#{column}=", next_id)
     end


### PR DESCRIPTION
This allows the `skip` lambda to check for existence of the sequential_id column
before accessing it.

Example:
```
acts_as_sequenced scope: :burrow_id, skip: ->(r) { !r.respond_to?(:sequential_id) }
```

Clarification:
I needed to run multiple migrations on the model I wanted to use `acts_as_sequenced` for before I could add the `sequential_id` column to the table. In order to prevent `acts_as_sequenced` to  fail due to accessing the missing column, I used a `skip` lambda.

However, the column was actually accessed before the lambda was executed. This pull request changes the behaviour so that `skip` is executed before accessing the column.