### PR TITLE
Fix failing tests due to changed migration API

### DIFF
--- a/test/concurrency_test.rb
+++ b/test/concurrency_test.rb
@@ -22,7 +22,7 @@ require 'test_helper'
 
 if ENV['DB'] == 'postgresql'
   class ConcurrencyTest < ActiveSupport::TestCase
-    self.use_transactional_fixtures = false
+    self.use_transactional_tests = false
 
     def setup
       ConcurrentBadger.delete_all

--- a/test/dummy/db/migrate/20120219165346_create_questions.rb
+++ b/test/dummy/db/migrate/20120219165346_create_questions.rb
@@ -1,4 +1,4 @@
-class CreateQuestions < ActiveRecord::Migration
+class CreateQuestions < ActiveRecord::Migration[4.2]
   def change
     create_table :questions do |t|
       t.string :summary

--- a/test/dummy/db/migrate/20120219165548_create_answers.rb
+++ b/test/dummy/db/migrate/20120219165548_create_answers.rb
@@ -1,4 +1,4 @@
-class CreateAnswers < ActiveRecord::Migration
+class CreateAnswers < ActiveRecord::Migration[4.2]
   def change
     create_table :answers do |t|
       t.references :question

--- a/test/dummy/db/migrate/20120219171957_create_accounts.rb
+++ b/test/dummy/db/migrate/20120219171957_create_accounts.rb
@@ -1,4 +1,4 @@
-class CreateAccounts < ActiveRecord::Migration
+class CreateAccounts < ActiveRecord::Migration[4.2]
   def change
     create_table :accounts do |t|
       t.string :name

--- a/test/dummy/db/migrate/20120219172039_create_invoices.rb
+++ b/test/dummy/db/migrate/20120219172039_create_invoices.rb
@@ -1,4 +1,4 @@
-class CreateInvoices < ActiveRecord::Migration
+class CreateInvoices < ActiveRecord::Migration[4.2]
   def change
     create_table :invoices do |t|
       t.integer :amount

--- a/test/dummy/db/migrate/20120219172922_create_orders.rb
+++ b/test/dummy/db/migrate/20120219172922_create_orders.rb
@@ -1,9 +1,9 @@
-class CreateOrders < ActiveRecord::Migration
+class CreateOrders < ActiveRecord::Migration[4.2]
   def change
     create_table :orders do |t|
       t.string :product
       t.references :account
-      
+
       t.timestamps
     end
   end

--- a/test/dummy/db/migrate/20120219174931_create_subscriptions.rb
+++ b/test/dummy/db/migrate/20120219174931_create_subscriptions.rb
@@ -1,4 +1,4 @@
-class CreateSubscriptions < ActiveRecord::Migration
+class CreateSubscriptions < ActiveRecord::Migration[4.2]
   def change
     create_table :subscriptions do |t|
       t.string :plan

--- a/test/dummy/db/migrate/20120219175744_create_users.rb
+++ b/test/dummy/db/migrate/20120219175744_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.references :account

--- a/test/dummy/db/migrate/20120219232323_create_addresses.rb
+++ b/test/dummy/db/migrate/20120219232323_create_addresses.rb
@@ -1,4 +1,4 @@
-class CreateAddresses < ActiveRecord::Migration
+class CreateAddresses < ActiveRecord::Migration[4.2]
   def change
     create_table :addresses do |t|
       t.references :account

--- a/test/dummy/db/migrate/20120220000804_create_comments.rb
+++ b/test/dummy/db/migrate/20120220000804_create_comments.rb
@@ -1,4 +1,4 @@
-class CreateComments < ActiveRecord::Migration
+class CreateComments < ActiveRecord::Migration[4.2]
   def change
     create_table :comments do |t|
       t.references :question

--- a/test/dummy/db/migrate/20130411225444_create_emails.rb
+++ b/test/dummy/db/migrate/20130411225444_create_emails.rb
@@ -1,4 +1,4 @@
-class CreateEmails < ActiveRecord::Migration
+class CreateEmails < ActiveRecord::Migration[4.2]
   def change
     create_table :emails do |t|
       t.string :emailable_type

--- a/test/dummy/db/migrate/20130715002029_create_ratings.rb
+++ b/test/dummy/db/migrate/20130715002029_create_ratings.rb
@@ -1,4 +1,4 @@
-class CreateRatings < ActiveRecord::Migration
+class CreateRatings < ActiveRecord::Migration[4.2]
   def change
     create_table :ratings do |t|
       t.references :comment

--- a/test/dummy/db/migrate/20130730004055_create_products.rb
+++ b/test/dummy/db/migrate/20130730004055_create_products.rb
@@ -1,4 +1,4 @@
-class CreateProducts < ActiveRecord::Migration
+class CreateProducts < ActiveRecord::Migration[4.2]
   def change
     create_table :products do |t|
       t.references :account

--- a/test/dummy/db/migrate/20131226000000_create_monsters.rb
+++ b/test/dummy/db/migrate/20131226000000_create_monsters.rb
@@ -1,4 +1,4 @@
-class CreateMonsters < ActiveRecord::Migration
+class CreateMonsters < ActiveRecord::Migration[4.2]
   def change
     create_table :monsters do |t|
       t.integer :sequential_id

--- a/test/dummy/db/migrate/20140404195334_create_policemen.rb
+++ b/test/dummy/db/migrate/20140404195334_create_policemen.rb
@@ -1,4 +1,4 @@
-class CreatePolicemen < ActiveRecord::Migration
+class CreatePolicemen < ActiveRecord::Migration[4.2]
   def change
     create_table :policemen do |t|
       t.integer :sequential_id

--- a/test/dummy/db/migrate/20151120190645_create_concurrent_badgers.rb
+++ b/test/dummy/db/migrate/20151120190645_create_concurrent_badgers.rb
@@ -1,4 +1,4 @@
-class CreateConcurrentBadgers < ActiveRecord::Migration
+class CreateConcurrentBadgers < ActiveRecord::Migration[4.2]
   def change
     create_table :concurrent_badgers do |t|
       t.integer :sequential_id, null: false

--- a/test/dummy/db/migrate/20160118182655_create_doppelgangers.rb
+++ b/test/dummy/db/migrate/20160118182655_create_doppelgangers.rb
@@ -1,4 +1,4 @@
-class CreateDoppelgangers < ActiveRecord::Migration
+class CreateDoppelgangers < ActiveRecord::Migration[4.2]
   def change
     create_table :doppelgangers do |t|
       t.integer :sequential_id_one

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require "rails/test_help"
 
 Rails.backtrace_cleaner.remove_silencers!
 
-ActiveRecord::Migrator.migrate(File.expand_path("../dummy/db/migrate/", __FILE__))
+ActiveRecord::MigrationContext.new(File.expand_path("../dummy/db/migrate/", __FILE__)).up
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
# Fix failing tests due to changed migration API, closes #35
The gemspec specifies rails version >= 3.1 which resolved to rails
5.2.1. In this version of rails the migration API had changed, resulting
in our test helper to fail.

Rails now requires the migrations to specify what rails version to use, which is why the dummy migrations have changed. 

Rails will automatically add indexes for foreign keys, which makes some migrations invalid for later rails versions. For example the `CreateAnswers` migration would try to create an already existing index.

Additionally the `transactional_fixtures` configuration present in the concurrency test has changed name to `transactional_tests` in rails 5.

I am assuming we want to run the latest version of rails since no specific version is defined?