### PR TITLE
Update gemspec to exclude test assets from compiled gem

### DIFF
--- a/sequenced.gemspec
+++ b/sequenced.gemspec
@@ -11,8 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = "Generate scoped sequential IDs for ActiveRecord models"
   s.description = "Sequenced is a gem that generates scoped sequential IDs for ActiveRecord models."
 
-  s.files = `git ls-files`.split("\n")
-  s.test_files = Dir["test/**/*"]
+  s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "activerecord", ">= 3.0"


### PR DESCRIPTION
We noticed that the .gem file unnecessarily includes the test directory, including a 3 megabyte test.log file after installation. I've updated the gemspec line with the latest convention from `bundle gem`'s generator, and removed the `test_files` directive which as far as I can tell never served a purpose, as is no longer included in the gemspec reference.