### PR TITLE
Fix: non-default primary key names not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased (Unreleased)
+
+* Fix: support non-default primary key columns (set via `primary_key=`)
+
 3.1.1 (January 30, 2016)
 -------------------------
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gemspec
 gem "jquery-rails"
 
 group :development, :test do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
   # gem 'mysql2'
   gem 'pg'
 end

--- a/lib/sequenced/generator.rb
+++ b/lib/sequenced/generator.rb
@@ -39,7 +39,7 @@ module Sequenced
     def unique?(id)
       build_scope(*scope) do
         rel = base_relation
-        rel = rel.where("NOT id = ?", record.id) if record.persisted?
+        rel = rel.where.not(record.class.primary_key => record.id) if record.persisted?
         rel.where(column => id)
       end.count == 0
     end

--- a/test/acts_as_sequenced_test.rb
+++ b/test/acts_as_sequenced_test.rb
@@ -2,19 +2,20 @@ require 'test_helper'
 
 # Test Models:
 #
-#   Answer       - :scope => :question_id
-#   Comment      - :scope => :question_id (with an AR default scope)
-#   Invoice      - :scope => :account_id, :start_at => 1000
-#   Product      - :scope => :account_id, :start_at => lambda { |r| r.computed_start_value }
-#   Order        - :scope => :non_existent_column
-#   User         - :scope => :account_id, :column => :custom_sequential_id
-#   Address      - :scope => :account_id ('sequential_id' does not exist)
-#   Email        - :scope => [:emailable_id, :emailable_type]
-#   Subscription - no options
-#   Rating       - :scope => :comment_id, skip: { |r| r.score == 0 }
-#   Monster      - no options
-#   Zombie       - STI, inherits from Monster
-#   Werewolf     - STI, inherits from Monster
+#   Answer               - :scope => :question_id
+#   Comment              - :scope => :question_id (with an AR default scope)
+#   Invoice              - :scope => :account_id, :start_at => 1000
+#   Product              - :scope => :account_id, :start_at => lambda { |r| r.computed_start_value }
+#   Order                - :scope => :non_existent_column
+#   User                 - :scope => :account_id, :column => :custom_sequential_id
+#   Address              - :scope => :account_id ('sequential_id' does not exist)
+#   Email                - :scope => [:emailable_id, :emailable_type]
+#   Subscription         - no options
+#   Rating               - :scope => :comment_id, skip: { |r| r.score == 0 }
+#   Monster              - no options
+#   Zombie               - STI, inherits from Monster
+#   Werewolf             - STI, inherits from Monster
+#   WithCustomPrimaryKey - non-default primary key
 
 class ActsAsSequencedTest < ActiveSupport::TestCase
   test "default start_at" do
@@ -164,5 +165,15 @@ class ActsAsSequencedTest < ActiveSupport::TestCase
     invoice2 = account2.invoices.create
 
     assert_equal invoice1.sequential_id, invoice2.sequential_id
+  end
+
+  test "sequences for model with non-standard primary key name" do
+    account = Account.create
+
+    record = WithCustomPrimaryKey.create(account: account)
+
+    assert record.persisted?
+    record.update_column(:sequential_id, nil)
+    assert record.save!
   end
 end

--- a/test/dummy/app/models/with_custom_primary_key.rb
+++ b/test/dummy/app/models/with_custom_primary_key.rb
@@ -1,0 +1,6 @@
+class WithCustomPrimaryKey < ActiveRecord::Base
+  self.primary_key = :legacy_id
+
+  belongs_to :account
+  acts_as_sequenced :scope => :account_id
+end

--- a/test/dummy/db/migrate/20190216124804_create_with_custom_primary_key.rb
+++ b/test/dummy/db/migrate/20190216124804_create_with_custom_primary_key.rb
@@ -1,0 +1,8 @@
+class CreateWithCustomPrimaryKey < ActiveRecord::Migration[5.2]
+  def change
+    create_table :with_custom_primary_keys, id: :integer, primary_key: :legacy_id do |t|
+      t.integer :sequential_id
+      t.references :account
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,132 +10,133 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160118182655) do
+ActiveRecord::Schema.define(version: 2019_02_16_124804) do
 
   create_table "accounts", force: :cascade do |t|
-    t.string   "name"
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "addresses", force: :cascade do |t|
-    t.integer  "account_id"
-    t.string   "city"
+    t.integer "account_id"
+    t.string "city"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "answers", force: :cascade do |t|
-    t.integer  "question_id"
-    t.text     "body"
-    t.integer  "sequential_id"
+    t.integer "question_id"
+    t.text "body"
+    t.integer "sequential_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["question_id"], name: "index_answers_on_question_id"
+    t.index ["sequential_id"], name: "index_answers_on_sequential_id"
   end
-
-  add_index "answers", ["question_id"], name: "index_answers_on_question_id"
-  add_index "answers", ["sequential_id"], name: "index_answers_on_sequential_id"
 
   create_table "comments", force: :cascade do |t|
-    t.integer  "question_id"
-    t.text     "body"
-    t.integer  "sequential_id"
+    t.integer "question_id"
+    t.text "body"
+    t.integer "sequential_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["question_id"], name: "index_comments_on_question_id"
   end
-
-  add_index "comments", ["question_id"], name: "index_comments_on_question_id"
 
   create_table "concurrent_badgers", force: :cascade do |t|
     t.integer "sequential_id", null: false
     t.integer "burrow_id"
+    t.index ["sequential_id", "burrow_id"], name: "unique_concurrent", unique: true
   end
 
-  add_index "concurrent_badgers", ["sequential_id", "burrow_id"], name: "unique_concurrent", unique: true
-
   create_table "doppelgangers", force: :cascade do |t|
-    t.integer  "sequential_id_one"
-    t.integer  "sequential_id_two"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.integer "sequential_id_one"
+    t.integer "sequential_id_two"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "emails", force: :cascade do |t|
-    t.string   "emailable_type"
-    t.integer  "emailable_id"
-    t.integer  "sequential_id"
-    t.string   "address"
+    t.string "emailable_type"
+    t.integer "emailable_id"
+    t.integer "sequential_id"
+    t.string "address"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "invoices", force: :cascade do |t|
-    t.integer  "amount"
-    t.integer  "sequential_id"
-    t.integer  "account_id"
+    t.integer "amount"
+    t.integer "sequential_id"
+    t.integer "account_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["account_id"], name: "index_invoices_on_account_id"
   end
 
-  add_index "invoices", ["account_id"], name: "index_invoices_on_account_id"
-
   create_table "monsters", force: :cascade do |t|
-    t.integer  "sequential_id"
-    t.string   "type"
+    t.integer "sequential_id"
+    t.string "type"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "orders", force: :cascade do |t|
-    t.string   "product"
-    t.integer  "account_id"
+    t.string "product"
+    t.integer "account_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "policemen", force: :cascade do |t|
-    t.integer  "sequential_id"
+    t.integer "sequential_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "products", force: :cascade do |t|
-    t.integer  "account_id"
-    t.integer  "sequential_id"
+    t.integer "account_id"
+    t.integer "sequential_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "questions", force: :cascade do |t|
-    t.string   "summary"
-    t.text     "body"
+    t.string "summary"
+    t.text "body"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "ratings", force: :cascade do |t|
-    t.integer  "comment_id"
-    t.integer  "score"
-    t.integer  "sequential_id"
+    t.integer "comment_id"
+    t.integer "score"
+    t.integer "sequential_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "subscriptions", force: :cascade do |t|
-    t.string   "plan"
-    t.integer  "sequential_id"
+    t.string "plan"
+    t.integer "sequential_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "users", force: :cascade do |t|
-    t.integer  "account_id"
-    t.string   "name"
-    t.integer  "custom_sequential_id"
+    t.integer "account_id"
+    t.string "name"
+    t.integer "custom_sequential_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["account_id"], name: "index_users_on_account_id"
   end
 
-  add_index "users", ["account_id"], name: "index_users_on_account_id"
+  create_table "with_custom_primary_keys", primary_key: "legacy_id", force: :cascade do |t|
+    t.integer "sequential_id"
+    t.integer "account_id"
+    t.index ["account_id"], name: "index_with_custom_primary_keys_on_account_id"
+  end
 
 end


### PR DESCRIPTION
The name of the primary key was hard-coded as 'id', when it should be found with 'primary_key'.

Closes #40