### PR TITLE
Fix issue with Postgres adapter check when using a subclassed adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.3
+  - 2.4.1
 
 env:
   - DB=sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ env:
 before_script:
   - rake db:create
 
-sudo: false
+services:
+  - postgresql

--- a/lib/sequenced/generator.rb
+++ b/lib/sequenced/generator.rb
@@ -54,7 +54,7 @@ module Sequenced
 
     def postgresql?
       defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) &&
-        record.class.connection.instance_of?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+        record.class.connection.kind_of?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
     end
 
     def base_relation


### PR DESCRIPTION
since `instance_of?` only returns true if the object is an instance of that exact class, I changed it to `kind_of?` to support all subclassed apdabters, for example `activerecord-postgis-adapter`.
