### PR TITLE
Avoid DEPRECATED in MiniTest: use assert_nil

### DIFF
--- a/test/acts_as_sequenced_test.rb
+++ b/test/acts_as_sequenced_test.rb
@@ -121,7 +121,7 @@ class ActsAsSequencedTest < ActiveSupport::TestCase
     assert_equal 1, rating.sequential_id
 
     rating = Rating.create(:comment_id => 1, :score => 0)
-    assert_equal nil, rating.sequential_id
+    assert_nil rating.sequential_id
   end
 
   test "STI" do


### PR DESCRIPTION
This PR avoids this warning:

```
# Running:

....DEPRECATED: Use assert_nil if expecting nil from /home/travis/build/derrickreimer/sequenced/test/acts_as_sequenced_test.rb:124. This will fail in Minitest 6.

.................

```

https://travis-ci.org/derrickreimer/sequenced/jobs/643416164#L479