### PR TITLE
add support for secondary sequences

### DIFF
--- a/lib/sequenced/acts_as_sequenced.rb
+++ b/lib/sequenced/acts_as_sequenced.rb
@@ -29,6 +29,10 @@ module Sequenced
       #           :skip     - Skips the sequential ID generation when the lambda
       #                       expression evaluates to nil. Gets passed the
       #                       model object
+      #           :secondary
+      #             :column - Column for secondary index
+      #             :value  - lambda expression that you want to use to generate value for secondary index.
+      #                       Accepts two attributes: record and next_id
       #
       # Examples
       #


### PR DESCRIPTION
I needed a way to generate invoice number with user-defined prefix. Thought that 'secondary sequences' can do that and still be useful for other use-cases.

Example
```ruby
acts_as_sequenced column: :invoice_number_sequential_id,
  secondary: { column: :invoice_number, value: -> (record, next_id) { "#{record.invoice_number_prefix}#{next_id}" } }
```

@derrickreimer I'm happy to update the README and add tests if you are ok with merging this feature.
Feedback is welcome 🙂 