### PR TITLE
Update test_helper for Rails 6+ compatibility

### DIFF
--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/test/dummy/config/storage.yml
+++ b/test/dummy/config/storage.yml
@@ -1,0 +1,3 @@
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,13 @@ require "rails/test_help"
 
 Rails.backtrace_cleaner.remove_silencers!
 
-ActiveRecord::MigrationContext.new(File.expand_path("../dummy/db/migrate/", __FILE__)).up
+migrate_path = File.expand_path("../dummy/db/migrate/", __FILE__)
+
+if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("6.0")
+  ActiveRecord::MigrationContext.new(migrate_path, ActiveRecord::SchemaMigration).up
+else
+  ActiveRecord::MigrationContext.new(migrate_path).up
+end
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }


### PR DESCRIPTION
Required arguments for ActiveRecord::MigrationContext have changed in https://github.com/rails/rails/pull/36439
