### PR TITLE
Delay inclusion of Sequenced until ActiveRecord is loaded

### DIFF
--- a/lib/sequenced.rb
+++ b/lib/sequenced.rb
@@ -1,4 +1,6 @@
 require 'sequenced/generator'
 require 'sequenced/acts_as_sequenced'
 
-ActiveRecord::Base.send(:include, Sequenced::ActsAsSequenced)
+ActiveSupport.on_load(:active_record) do
+  include Sequenced::ActsAsSequenced
+end


### PR DESCRIPTION
Doing so prevent loading ActiveRecord too early. Loading too early can cause many problem, the most frequent is configuration in initializers being ignored.