### PR TITLE
Avoid acquiring full table locks in PostgreSQL

### DIFF
--- a/lib/sequenced/generator.rb
+++ b/lib/sequenced/generator.rb
@@ -50,9 +50,9 @@ module Sequenced
     private
 
     def lock_table
-      if postgresql?
-        record.class.connection.execute("LOCK TABLE #{record.class.table_name} IN EXCLUSIVE MODE")
-      end
+      return unless postgresql?
+
+      build_scope(*scope) { base_relation.select(1).lock(true) }.load
     end
 
     def postgresql?


### PR DESCRIPTION
As noted in #58, full table locks are dangerous and can be avoided by acquiring locking only records associated to the parent. This patch uses the `build_scope` interface to do a quick `SELECT 1 FROM ... FOR UPDATE` that should work both for scoped and unscoped sequence columns.

Also worth mentioning: I didn't touch the tests because I'm pretty unsure of the best way to test this, or if modification of our tests is even necessary. If there's a good way to modify the concurrency test so that the lock is exercised, I'm happy to do so. I did verify in our own application that this correctly issues a `SELECT ... FOR UPDATE` query and avoids the full table lock.